### PR TITLE
Ingredient metadata was keyed wrong

### DIFF
--- a/src/Core/Provisioning/DataStore.cs
+++ b/src/Core/Provisioning/DataStore.cs
@@ -71,7 +71,7 @@ namespace KitchenPC.Data
       public Dictionary<Guid, IngredientMetadata> GetIndexedIngredientMetadata()
       {
          if (indexedIngredientMetadata == null)
-            indexedIngredientMetadata = IngredientMetadata.ToDictionary(i => i.IngredientMetadataId);
+            indexedIngredientMetadata = IngredientMetadata.ToDictionary(i => i.IngredientId);
 
          return indexedIngredientMetadata;
       }

--- a/src/KitchenPC.sln
+++ b/src/KitchenPC.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.21005.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core", "Core\Core.csproj", "{51CD9FFD-2615-4E55-90D5-C18B1BF7FE07}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnitTests", "UnitTests\UnitTests.csproj", "{E7D7ADC3-D224-40DD-959A-C71310250806}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DB", "DB\DB.csproj", "{F9AC98DE-512F-4491-90D8-B21CBE0F3F2A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KPCTest", "..\..\..\Documents\Visual Studio 2013\Projects\KPCTest\KPCTest\KPCTest.csproj", "{014DA469-4A46-4FA2-84D5-4E3E16251948}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,6 +36,12 @@ Global
 		{F9AC98DE-512F-4491-90D8-B21CBE0F3F2A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F9AC98DE-512F-4491-90D8-B21CBE0F3F2A}.Staging|Any CPU.ActiveCfg = Release|Any CPU
 		{F9AC98DE-512F-4491-90D8-B21CBE0F3F2A}.Staging|Any CPU.Build.0 = Release|Any CPU
+		{014DA469-4A46-4FA2-84D5-4E3E16251948}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{014DA469-4A46-4FA2-84D5-4E3E16251948}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{014DA469-4A46-4FA2-84D5-4E3E16251948}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{014DA469-4A46-4FA2-84D5-4E3E16251948}.Release|Any CPU.Build.0 = Release|Any CPU
+		{014DA469-4A46-4FA2-84D5-4E3E16251948}.Staging|Any CPU.ActiveCfg = Release|Any CPU
+		{014DA469-4A46-4FA2-84D5-4E3E16251948}.Staging|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
GetIndexedIngredientMetadata should be keyed by the IngredientId (so recipes using that ingredient can look up metadata for that ingredient) and not the MetadataId (which is basically meaningless).
