### PR TITLE
Restore recipe search paging

### DIFF
--- a/src/Core/Context/StaticSearch.cs
+++ b/src/Core/Context/StaticSearch.cs
@@ -156,45 +156,52 @@ internal class StaticSearch : ISearchProvider
          case RecipeQuery.SortOrder.Title:
             q =
                (query.Direction == RecipeQuery.SortDirection.Ascending)
-                  ? q.OrderBy(p => p.Recipe.Title)
-                  : q.OrderByDescending(p => p.Recipe.Title);
+                  ? q.OrderBy(p => p.Recipe.Title).ThenBy(p => p.Recipe.RecipeId)
+                  : q.OrderByDescending(p => p.Recipe.Title).ThenBy(p => p.Recipe.RecipeId);
             break;
          case RecipeQuery.SortOrder.PrepTime:
             q =
                (query.Direction == RecipeQuery.SortDirection.Ascending)
-                  ? q.OrderBy(p => p.Recipe.PrepTime)
-                  : q.OrderByDescending(p => p.Recipe.PrepTime);
+                  ? q.OrderBy(p => p.Recipe.PrepTime).ThenBy(p => p.Recipe.RecipeId)
+                  : q.OrderByDescending(p => p.Recipe.PrepTime).ThenBy(p => p.Recipe.RecipeId);
             break;
          case RecipeQuery.SortOrder.CookTime:
             q =
                (query.Direction == RecipeQuery.SortDirection.Ascending)
-                  ? q.OrderBy(p => p.Recipe.CookTime)
-                  : q.OrderByDescending(p => p.Recipe.CookTime);
+                  ? q.OrderBy(p => p.Recipe.CookTime).ThenBy(p => p.Recipe.RecipeId)
+                  : q.OrderByDescending(p => p.Recipe.CookTime).ThenBy(p => p.Recipe.RecipeId);
             break;
          case RecipeQuery.SortOrder.TotalTime:
             q =
                (query.Direction == RecipeQuery.SortDirection.Ascending)
                   ? q.OrderBy(p => p.Recipe.PrepTime + p.Recipe.CookTime)
-                  : q.OrderByDescending(p => p.Recipe.PrepTime + p.Recipe.CookTime);
+                     .ThenBy(p => p.Recipe.RecipeId)
+                  : q.OrderByDescending(p => p.Recipe.PrepTime + p.Recipe.CookTime)
+                     .ThenBy(p => p.Recipe.RecipeId);
             break;
          case RecipeQuery.SortOrder.Image:
             q =
                (query.Direction == RecipeQuery.SortDirection.Ascending)
-                  ? q.OrderBy(p => p.Recipe.ImageUrl)
-                  : q.OrderByDescending(p => p.Recipe.ImageUrl);
+                  ? q.OrderBy(p => p.Recipe.ImageUrl).ThenBy(p => p.Recipe.RecipeId)
+                  : q.OrderByDescending(p => p.Recipe.ImageUrl).ThenBy(p => p.Recipe.RecipeId);
             break;
          default:
             q =
                (query.Direction == RecipeQuery.SortDirection.Ascending)
-                  ? q.OrderBy(p => p.Recipe.Rating)
-                  : q.OrderByDescending(p => p.Recipe.Rating);
+                  ? q.OrderBy(p => p.Recipe.Rating).ThenBy(p => p.Recipe.RecipeId)
+                  : q.OrderByDescending(p => p.Recipe.Rating).ThenBy(p => p.Recipe.RecipeId);
             break;
       }
 
+      var totalCount = q.LongCount();
+
       return new SearchResults
       {
-         Briefs = q.Select(r => Provisioning.DTO.Recipes.ToRecipeBrief(r.Recipe)).ToArray(),
-         TotalCount = q.Count(),
+         Briefs = q.Skip(query.Offset)
+            .Take(RecipeQuery.PageSize)
+            .Select(r => Provisioning.DTO.Recipes.ToRecipeBrief(r.Recipe))
+            .ToArray(),
+         TotalCount = totalCount,
       };
    }
 

--- a/src/Core/Properties/AssemblyInfo.cs
+++ b/src/Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnitTests")]

--- a/src/Core/Recipes/RecipeQuery.cs
+++ b/src/Core/Recipes/RecipeQuery.cs
@@ -4,6 +4,8 @@ namespace KitchenPC.Core.Recipes;
 
 public class RecipeQuery
 {
+   public const int PageSize = 100;
+
    public enum PhotoFilter
    {
       All = 0,

--- a/src/DB/NHSearch.cs
+++ b/src/DB/NHSearch.cs
@@ -224,19 +224,20 @@ public class NHSearch : ISearchProvider
          RecipeQuery.SortOrder.Image => q.OrderBy(p => p.ImageUrl),
          _ => q.OrderBy(p => p.Rating),
       };
-      var results = (
+      var totalCount = await q.ToRowCountInt64Query().RowCountInt64Async(cancellationToken);
+      var results = await (
          query.Direction == RecipeQuery.SortDirection.Descending ? orderBy.Desc() : orderBy.Asc()
       )
+         .ThenBy(p => p.RecipeId)
+         .Asc()
          .Skip(query.Offset)
-         .Take(100)
+         .Take(RecipeQuery.PageSize)
          .ListAsync(cancellationToken);
-
-      var loadedResults = await results;
 
       return new SearchResults
       {
-         Briefs = loadedResults.Select(r => r.AsRecipeBrief()).ToArray(),
-         TotalCount = loadedResults.Count, // TODO: This needs to be the total matches, not the returned matches
+         Briefs = results.Select(r => r.AsRecipeBrief()).ToArray(),
+         TotalCount = totalCount,
       };
    }
 }

--- a/src/UnitTests/RecipeSearch.cs
+++ b/src/UnitTests/RecipeSearch.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using KitchenPC.Core;
+using KitchenPC.Core.Context;
+using KitchenPC.Core.Provisioning;
+using KitchenPC.Core.Recipes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RecipeDto = KitchenPC.Core.Provisioning.DTO.Recipes;
+
+namespace KitchenPC.UnitTests;
+
+[TestClass]
+public class RecipeSearchTest
+{
+   [TestMethod]
+   public void StaticSearchReturnsStablePagesAndTotalCount()
+   {
+      var recipes = Enumerable
+         .Range(0, 205)
+         .Select(index => new RecipeDto
+         {
+            RecipeId = new Guid(index + 1, 0, 0, new byte[8]),
+            Title = $"Recipe {index:D3}",
+         })
+         .ToList();
+      var store = new DataStore
+      {
+         Recipes = recipes,
+         RecipeIngredients = [],
+         RecipeMetadata = [],
+      };
+      var search = new StaticSearch(store);
+
+      var firstPage = search.Search(AuthIdentity.Anonymous, CreateQuery(0));
+      var secondPage = search.Search(AuthIdentity.Anonymous, CreateQuery(100));
+      var finalPage = search.Search(AuthIdentity.Anonymous, CreateQuery(200));
+      var beyondEnd = search.Search(AuthIdentity.Anonymous, CreateQuery(300));
+
+      Assert.AreEqual(205, firstPage.TotalCount);
+      Assert.AreEqual(RecipeQuery.PageSize, firstPage.Briefs.Length);
+      Assert.AreEqual(205, secondPage.TotalCount);
+      Assert.AreEqual(RecipeQuery.PageSize, secondPage.Briefs.Length);
+      Assert.AreEqual(205, finalPage.TotalCount);
+      Assert.AreEqual(5, finalPage.Briefs.Length);
+      Assert.AreEqual(205, beyondEnd.TotalCount);
+      Assert.AreEqual(0, beyondEnd.Briefs.Length);
+
+      CollectionAssert.AreEqual(
+         recipes.Take(RecipeQuery.PageSize).Select(recipe => recipe.RecipeId).ToArray(),
+         firstPage.Briefs.Select(recipe => recipe.Id).ToArray()
+      );
+      CollectionAssert.AreEqual(
+         recipes
+            .Skip(RecipeQuery.PageSize)
+            .Take(RecipeQuery.PageSize)
+            .Select(recipe => recipe.RecipeId)
+            .ToArray(),
+         secondPage.Briefs.Select(recipe => recipe.Id).ToArray()
+      );
+   }
+
+   private static RecipeQuery CreateQuery(int offset) =>
+      new()
+      {
+         Offset = offset,
+         Sort = RecipeQuery.SortOrder.Title,
+         Direction = RecipeQuery.SortDirection.Ascending,
+      };
+}


### PR DESCRIPTION
## Summary

- return the total number of matching recipes independently of the current 100-result page
- apply the same paging contract to database-backed and in-memory search providers
- add a stable `RecipeId` tie-breaker so adjacent offset pages cannot reorder equal-valued results
- expose the shared 100-result page size through `RecipeQuery.PageSize`
- add a fast regression test covering full, partial, and beyond-end pages

## Validation

- `dotnet build DB/DB.csproj --configuration Release --no-restore`
- `dotnet test UnitTests/UnitTests.csproj --configuration Release --no-restore` (22 passed)
- exercised the database provider through the Website API against PostgreSQL
- verified 55,102 total matches with 100 results at offsets 0 and 100
- verified no duplicate IDs and stable ordering between adjacent pages
- verified an offset beyond the result set returns an empty page while preserving the total count
- verified filtered adjacent pages report the same total count

A matching Core/DB v1.0.1 release can be tagged after this PR is merged.